### PR TITLE
Fix composer dependence  on nette/application 3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
   "require": {
     "php": ">=7.1",
     "nette/di": "^2.4.7 || ^3.0",
+    "nette/application": "^3.2",
     "onelogin/php-saml": "^4.0"
   },
   "require-dev": {


### PR DESCRIPTION
To avoid stack trace exception Call to undefined method: Nette\Application\LinkGenerator::requestToUrl().

Method is present in version 3.2 of nette/application package