### PR TITLE
Separate fuctionaltity of imported lib to Adapter implementing defined interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,9 @@
   },
   "require-dev": {
     "nette/tester": "@dev",
-    "nette/application": "@dev",
     "tracy/tracy": "@dev"
   },
   "autoload": {
     "classmap": ["src/"]
-  },
-  "config": {
-    "allow-plugins": {
-      "simplesamlphp/composer-xmlprovider-installer": true,
-      "simplesamlphp/composer-module-installer": true
-    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
     "php": ">=8.1",
     "nette/di": "^2.4.7 || ^3.0",
     "nette/application": "^3.2 || ^4.0",
-    "onelogin/php-saml": "^4.0",
-    "litesaml/lightsaml": "^4.5"
+    "onelogin/php-saml": "^4.0"
   },
   "require-dev": {
     "nette/tester": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,11 @@
     "php-saml"
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=8.1",
     "nette/di": "^2.4.7 || ^3.0",
     "nette/application": "^3.2 || ^4.0",
-    "onelogin/php-saml": "^4.0"
+    "onelogin/php-saml": "^4.0",
+    "litesaml/lightsaml": "^4.5"
   },
   "require-dev": {
     "nette/tester": "@dev",
@@ -20,5 +21,11 @@
   },
   "autoload": {
     "classmap": ["src/"]
+  },
+  "config": {
+    "allow-plugins": {
+      "simplesamlphp/composer-xmlprovider-installer": true,
+      "simplesamlphp/composer-module-installer": true
+    }
   }
 }

--- a/src/Adapter/LightSamlAdapter.php
+++ b/src/Adapter/LightSamlAdapter.php
@@ -1,4 +1,8 @@
 <?php
+// pokud by se pripravovala varianta pro litesaml (nebo treba simplesaml),
+// oba by meli umel back channel logout
+// musi se nacist prislsna knihovna i composerem
+
 namespace Sitmp\Saml\Adapter;
 
 use Sitmp\Saml\SamlAcs;

--- a/src/Adapter/LightSamlAdapter.php
+++ b/src/Adapter/LightSamlAdapter.php
@@ -2,33 +2,43 @@
 // pokud by se pripravovala varianta pro litesaml (nebo treba simplesaml),
 // oba by meli umel back channel logout
 // musi se nacist prislsna knihovna i composerem
+// composer require litesaml/lightsaml symfony/http-foundation psr/log
+
+declare(strict_types=1);
 
 namespace Sitmp\Saml\Adapter;
 
 use Sitmp\Saml\SamlAcs;
 use Sitmp\Saml\SamlAdapter;
+/*
+use LightSaml\Binding\HttpPostBinding;
+use LightSaml\Binding\HttpRedirectBinding;
+use LightSaml\Builder\EntityDescriptor\SimpleEntityDescriptorBuilder;
+use LightSaml\Context\Profile\MessageContext;
+use LightSaml\Credential\KeyHelper;
+use LightSaml\Credential\X509Certificate;
+use LightSaml\Helper;
+use LightSaml\Model\Assertion\Issuer;
+use LightSaml\Model\Metadata\SingleLogoutService;
+use LightSaml\Model\Protocol\AuthnRequest;
+use LightSaml\Model\Protocol\LogoutRequest;
+use LightSaml\Model\Protocol\LogoutResponse;
+use LightSaml\Model\Protocol\Response as SamlResponse;
+use LightSaml\Model\XmlDSig\SignatureWriter;
+use LightSaml\SamlConstants;
+use LightSaml\Validator\Model\Signature\SignatureValidator;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-
-//use LightSaml\Model\Protocol\AuthnRequest;
-//use LightSaml\Model\Protocol\LogoutRequest;
-//use LightSaml\Model\Assertion\Issuer;
-//use LightSaml\SamlConstants;
-//use LightSaml\Helper;
-//use LightSaml\Binding\HttpRedirectBinding;
-//use LightSaml\Binding\HttpPostBinding;
-//use LightSaml\Context\Profile\MessageContext;
-
+*/
 
 final class LightSamlAdapter implements SamlAdapter
 {
-    //private Config $cfg;
-    //private \SessionHandlerInterface|\SessionIdInterface|\ArrayAccess $session // z Nette: \Nette\Http\SessionSection
-
+    private array $settings;
 
     public function __construct(array $settings)
     {
-
+        $this->settings = $settings;
     }
 
 
@@ -36,67 +46,258 @@ final class LightSamlAdapter implements SamlAdapter
     public function login(?string $returnTo = null): void
     {
         throw new \Exception('Not implemented yet');
-        /*[$spCert, $spKey] = KeyLoader::loadSpKeyPair($this->cfg->spCertFile, $this->cfg->spKeyFile);
+        /*
+        [$spCert, $spKey] = $this->loadSpKeyPair();
 
         $authn = (new AuthnRequest())
             ->setID(Helper::generateID())
             ->setIssueInstant(new \DateTimeImmutable())
-            ->setDestination($this->cfg->idpSsoUrl)
-            ->setProtocolBinding(SamlConstants::BINDING_SAML2_HTTP_POST) // očekávaný binding odpovědi
-            ->setAssertionConsumerServiceURL($this->cfg->acsUrl)
-            ->setIssuer(new Issuer($this->cfg->spEntityId));
+            ->setDestination($this->config->idpSsoUrl)
+            // očekávaný binding odpovědi IdP → ACS (většinou POST)
+            ->setProtocolBinding(SamlConstants::BINDING_SAML2_HTTP_POST)
+            ->setAssertionConsumerServiceURL($this->config->acsUrl)
+            ->setIssuer(new Issuer($this->config->spEntityId));
 
-        if ($this->cfg->nameIdFormat) {
-            $authn->setNameIDPolicy((new \LightSaml\Model\Protocol\NameIDPolicy())
-                ->setFormat($this->cfg->nameIdFormat)
-                ->setAllowCreate(true));
+        if (!empty($this->config->nameIdFormat)) {
+            $authn->setNameIDPolicy(
+                (new \LightSaml\Model\Protocol\NameIDPolicy())
+                    ->setFormat($this->config->nameIdFormat)
+                    ->setAllowCreate(true)
+            );
         }
 
         if ($spKey && $spCert) {
-            $authn->setSignature(new \LightSaml\Model\XmlDSig\SignatureWriter($spKey, $spCert));
+            $authn->setSignature(new SignatureWriter($spKey, $spCert));
         }
-
-        // Redirect binding pro odeslání AuthnRequest na IdP
-        $binding = new HttpRedirectBinding();
-        $symfonyResponse = new Response();
-        $binding->send($authn, $symfonyResponse, $this->cfg->idpSsoUrl, ['RelayState' => $returnTo ?? '']);
-        $this->outputAndExit($symfonyResponse);*/
-    }
-
-    function acs($authErrorCallback,$genericErrorCallback): SamlAcs
-    {
-        throw new \Exception('Not implemented');
-    }
-
-    public function logout(?string $returnTo, array $parameters, mixed $nameId, mixed $sessionIndex, bool $stay, mixed $nameIdFormat, mixed $samlNameIdNameQualifier, mixed $samlNameIdSPNameQualifier): void
-    {
-        throw new \Exception('not implemented yet');
-        /*
-        $req = (new LogoutRequest())
-            ->setID(Helper::generateID())
-            ->setIssueInstant(new \DateTimeImmutable())
-            ->setDestination($this->cfg->idpSloUrl)
-            ->setIssuer(new Issuer($this->cfg->spEntityId))
-            ->setNameID((new \LightSaml\Model\Assertion\NameID())->setValue((string)$this->getNameId()));
 
         $binding = new HttpRedirectBinding();
         $resp = new Response();
-        $binding->send($req, $resp, $this->cfg->idpSloUrl, ['RelayState' => $returnTo ?? '']);
-        $this->outputAndExit($resp);
+        $binding->send($authn, $resp, $this->config->idpSsoUrl, [
+            'RelayState' => (string)($returnTo ?? ''),
+        ]);
+
+        $this->emit($resp);
         */
     }
 
-    public function slo($successCallback,$authErrorCallback): void
+    function acs(?callable $authErrorCallback = null,?callable $genericErrorCallback = null): SamlAcs
+    {
+        throw new \Exception('Not implemented');
+        /*try {
+            $httpReq = Request::createFromGlobals();
+
+            // SAMLResponse typicky dorazí POSTem
+            $ctx = new MessageContext();
+            (new HttpPostBinding())->receive($httpReq, $ctx);
+
+
+            $resp = $ctx->getMessage();
+
+            // 1) Validace podpisu proti IdP certifikátu
+            $idpCert = X509Certificate::fromFile($this->config->idpCert);
+            (new SignatureValidator())->validate($resp, [$idpCert]);
+
+            // 2) Kontroly issuer/audience/destination (doporučujeme ponechat)
+            $issuer = (string)$resp->getIssuer();
+            if ($issuer === '') {
+                throw new \RuntimeException('SAML Response missing Issuer');
+            }
+            $destination = (string)$resp->getDestination();
+            if ($destination && rtrim($destination, '/') !== rtrim($this->config->acsUrl, '/')) {
+                throw new \RuntimeException('SAML Response Destination mismatch');
+            }
+
+            $assertion = $resp->getFirstAssertion();
+            if (!$assertion) {
+                throw new \RuntimeException('No Assertion in SAML Response');
+            }
+
+            // 3) Extrakce údajů
+            $nameIdObj = $assertion->getSubject()?->getNameID();
+            $nameId = $nameIdObj?->getValue();
+            $nameIdFormat = $nameIdObj?->getFormat();
+            $nameIdNameQualifier = $nameIdObj?->getNameQualifier();
+            $nameIdSPNameQualifier = $nameIdObj?->getSPNameQualifier();
+            $sessionIndex = $assertion->getFirstAuthnStatement()?->getSessionIndex();
+
+            $attrs = [];
+            $attrStmt = $assertion->getFirstAttributeStatement();
+            if ($attrStmt) {
+                foreach ($attrStmt->getAllAttributes() as $a) {
+                    $attrs[$a->getName()] = $a->getAllAttributeValues();
+                }
+            }
+
+            // 5) DTO pro volající vrstvu
+            return new SamlAcs(
+                $nameId,
+                $nameIdFormat,
+                $attrs,
+                $nameIdNameQualifier,
+                $nameIdSPNameQualifier,
+                $sessionIndex,
+            );
+        } catch (\Throwable $e) {
+            // „auth“ chyby pošli auth callbacku, ostatní generic
+            $authErrors = [
+                'Signature', 'Issuer', 'Assertion', 'Audience', 'Destination', 'NotOnOrAfter', 'NotBefore'
+            ];
+            $msg = $e->getMessage();
+            if (array_reduce($authErrors, fn($c,$k)=>$c||str_contains($msg,$k), false)) {
+                $authErrorCallback($e);
+            } else {
+                $genericErrorCallback($e);
+            }
+        }*/
+    }
+
+    public function logout(
+        ?string $returnTo = null,
+        array $parameters = [],
+        ?string $nameId = null,
+        ?string $sessionIndex = null,
+        bool $stay = false,
+        ?string $nameIdFormat = null,
+        ?string $nameIdNameQualifier = null,
+        ?string $nameIdSPNameQualifier = null
+    ): void
     {
         throw new \Exception('not implemented yet');
+        /*
+       [$spCert, $spKey] = $this->loadSpKeyPair();
+
+        $req = (new LogoutRequest())
+            ->setID(Helper::generateID())
+            ->setIssueInstant(new \DateTimeImmutable())
+            ->setDestination($this->config->idpSloUrl)
+            ->setIssuer(new Issuer($this->config->spEntityId));
+
+        if ($nameId) {
+            $name = (new \LightSaml\Model\Assertion\NameID())
+                ->setValue($nameId)
+                ->setFormat($nameIdFormat ?: null)
+                ->setNameQualifier($nameIdNameQualifier ?: null)
+                ->setSPNameQualifier($nameIdSPNameQualifier ?: null);
+            $req->setNameID($name);
+        }
+        if ($sessionIndex) {
+            $req->setSessionIndex($sessionIndex);
+        }
+        if ($spKey && $spCert) {
+            $req->setSignature(new SignatureWriter($spKey, $spCert));
+        }
+
+        $binding = new HttpRedirectBinding();
+        $resp = new Response();
+        $relay = $parameters['RelayState'] ?? (string)($returnTo ?? '');
+        $binding->send($req, $resp, $this->config->idpSloUrl, ['RelayState' => $relay]);
+
+        $this->emit($resp);
+        */
+    }
+
+    public function slo(?callable $successCallback = null,?callable $authErrorCallback = null): void
+    {
+        throw new \Exception('not implemented yet');
+        /*
+    try {
+            $httpReq = Request::createFromGlobals();
+
+            $ctx = new MessageContext();
+            if ($httpReq->isMethod('POST') && ($httpReq->request->has('SAMLRequest') || $httpReq->request->has('SAMLResponse'))) {
+                (new HttpPostBinding())->receive($httpReq, $ctx);
+            } else {
+                (new HttpRedirectBinding())->receive($httpReq, $ctx);
+            }
+
+            $msg = $ctx->getMessage();
+
+            // validace podpisu
+            $idpCert = X509Certificate::fromFile($this->config->idpCert);
+            (new SignatureValidator())->validate($msg, [$idpCert]);
+
+            if ($msg instanceof LogoutRequest) {
+                // ukonči lokální session
+                $this->session['saml.auth'] = false;
+                $this->session['saml.nameId'] = null;
+                $this->session['saml.sessionIndex'] = null;
+                $this->session['saml.attrs'] = [];
+
+                // pošli SUCCESS odpověď zpět IdP
+                $resp = (new LogoutResponse())
+                    ->setID(Helper::generateID())
+                    ->setInResponseTo($msg->getID())
+                    ->setIssueInstant(new \DateTimeImmutable())
+                    ->setDestination($this->config->idpSloUrl)
+                    ->setStatus(new \LightSaml\Model\Protocol\Status(
+                        new \LightSaml\Model\Protocol\StatusCode(SamlConstants::STATUS_SUCCESS)
+                    ));
+
+                (new HttpRedirectBinding())->send($resp, new Response(), $this->config->idpSloUrl, [
+                    'RelayState' => (string)($httpReq->get('RelayState') ?? ''),
+                ]);
+
+                $successCallback();
+                return;
+            }
+
+            if ($msg instanceof LogoutResponse) {
+                // dokončeno – přesměruj na RelayState (pokud je)
+                $returnTo = (string)($httpReq->get('RelayState') ?? '');
+                if ($returnTo !== '') {
+                    header('Location: '.$returnTo);
+                    exit;
+                }
+                $successCallback();
+                return;
+            }
+
+            throw new \RuntimeException('Unsupported SLO message');
+        } catch (\Throwable $e) {
+            ($this->logger?->error('SAML SLO failed: '.$e->getMessage())) ?? null;
+            $authErrorCallback($e);
+            throw $e;
+        }
+         */
     }
 
     public function getMetadata(): string
     {
         throw new \Exception('not implemented yet');
+        /*
+     $cert = is_string($this->config->spCert ?? null) && $this->config->spCert !== ''
+            ? X509Certificate::fromFile($this->config->spCert)
+            : null;
+
+        $builder = new SimpleEntityDescriptorBuilder(
+            $this->config->spEntityId,
+            $this->config->acsUrl,
+            $cert
+        );
+
+        $entity = $builder->get();
+        $sp = $entity->getFirstSpSsoDescriptor();
+
+        // Publikuj oba SLO bindingy na stejné SLS URL
+        $sp->addSingleLogoutService(new SingleLogoutService(
+            SamlConstants::BINDING_SAML2_HTTP_POST,
+            $this->config->slsUrl
+        ));
+        $sp->addSingleLogoutService(new SingleLogoutService(
+            SamlConstants::BINDING_SAML2_HTTP_REDIRECT,
+            $this->config->slsUrl
+        ));
+
+        if (!empty($this->config->nameIdFormat)) {
+            $sp->addNameIDFormat($this->config->nameIdFormat);
+        }
+
+        $xml = $entity->toXml()->ownerDocument->saveXML();
+        return (string)$xml;
+        */
     }
 
-    private function outputAndExit(Response $response): void
+    /*private function outputAndExit(Response $response): void
     {
         // v Nette to převeď na IResponse, tady pro POC pošlu hlavičky a umřu
         foreach ($response->headers->allPreserveCase() as $k => $vals) {
@@ -105,6 +306,37 @@ final class LightSamlAdapter implements SamlAdapter
         http_response_code($response->getStatusCode());
         echo $response->getContent();
         exit;
+    }*/
+
+    /* =========================
+    Helpers
+    ========================= */
+
+    /** @return array{0:?X509Certificate,1:? \LightSaml\Credential\PrivateKey} */
+    /*private function loadSpKeyPair(): array
+    {
+        $spCert = null;
+        $spKey = null;
+
+        if (!empty($this->config->spCert)) {
+            $spCert = X509Certificate::fromFile($this->config->spCert);
+        }
+        if (!empty($this->config->spKey)) {
+            $spKey = KeyHelper::createPrivateKey($this->config->spKey, null, true);
+        }
+        return [$spCert, $spKey];
     }
+
+    private function emit(Response $response): void
+    {
+        foreach ($response->headers->allPreserveCase() as $name => $values) {
+            foreach ($values as $v) {
+                header($name . ': ' . $v, false);
+            }
+        }
+        http_response_code($response->getStatusCode());
+        echo $response->getContent();
+        exit;
+    }*/
 }
 

--- a/src/Adapter/LightSamlAdapter.php
+++ b/src/Adapter/LightSamlAdapter.php
@@ -1,0 +1,106 @@
+<?php
+namespace Sitmp\Saml\Adapter;
+
+use Sitmp\Saml\SamlAcs;
+use Sitmp\Saml\SamlAdapter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+//use LightSaml\Model\Protocol\AuthnRequest;
+//use LightSaml\Model\Protocol\LogoutRequest;
+//use LightSaml\Model\Assertion\Issuer;
+//use LightSaml\SamlConstants;
+//use LightSaml\Helper;
+//use LightSaml\Binding\HttpRedirectBinding;
+//use LightSaml\Binding\HttpPostBinding;
+//use LightSaml\Context\Profile\MessageContext;
+
+
+final class LightSamlAdapter implements SamlAdapter
+{
+    //private Config $cfg;
+    //private \SessionHandlerInterface|\SessionIdInterface|\ArrayAccess $session // z Nette: \Nette\Http\SessionSection
+
+
+    public function __construct(array $settings)
+    {
+
+    }
+
+
+
+    public function login(?string $returnTo = null): void
+    {
+        throw new \Exception('Not implemented yet');
+        /*[$spCert, $spKey] = KeyLoader::loadSpKeyPair($this->cfg->spCertFile, $this->cfg->spKeyFile);
+
+        $authn = (new AuthnRequest())
+            ->setID(Helper::generateID())
+            ->setIssueInstant(new \DateTimeImmutable())
+            ->setDestination($this->cfg->idpSsoUrl)
+            ->setProtocolBinding(SamlConstants::BINDING_SAML2_HTTP_POST) // očekávaný binding odpovědi
+            ->setAssertionConsumerServiceURL($this->cfg->acsUrl)
+            ->setIssuer(new Issuer($this->cfg->spEntityId));
+
+        if ($this->cfg->nameIdFormat) {
+            $authn->setNameIDPolicy((new \LightSaml\Model\Protocol\NameIDPolicy())
+                ->setFormat($this->cfg->nameIdFormat)
+                ->setAllowCreate(true));
+        }
+
+        if ($spKey && $spCert) {
+            $authn->setSignature(new \LightSaml\Model\XmlDSig\SignatureWriter($spKey, $spCert));
+        }
+
+        // Redirect binding pro odeslání AuthnRequest na IdP
+        $binding = new HttpRedirectBinding();
+        $symfonyResponse = new Response();
+        $binding->send($authn, $symfonyResponse, $this->cfg->idpSsoUrl, ['RelayState' => $returnTo ?? '']);
+        $this->outputAndExit($symfonyResponse);*/
+    }
+
+    function acs($authErrorCallback,$genericErrorCallback): SamlAcs
+    {
+        throw new \Exception('Not implemented');
+    }
+
+    public function logout(?string $returnTo, array $parameters, mixed $nameId, mixed $sessionIndex, bool $stay, mixed $nameIdFormat, mixed $samlNameIdNameQualifier, mixed $samlNameIdSPNameQualifier): void
+    {
+        throw new \Exception('not implemented yet');
+        /*
+        $req = (new LogoutRequest())
+            ->setID(Helper::generateID())
+            ->setIssueInstant(new \DateTimeImmutable())
+            ->setDestination($this->cfg->idpSloUrl)
+            ->setIssuer(new Issuer($this->cfg->spEntityId))
+            ->setNameID((new \LightSaml\Model\Assertion\NameID())->setValue((string)$this->getNameId()));
+
+        $binding = new HttpRedirectBinding();
+        $resp = new Response();
+        $binding->send($req, $resp, $this->cfg->idpSloUrl, ['RelayState' => $returnTo ?? '']);
+        $this->outputAndExit($resp);
+        */
+    }
+
+    public function slo($successCallback,$authErrorCallback): void
+    {
+        throw new \Exception('not implemented yet');
+    }
+
+    public function getMetadata(): string
+    {
+        throw new \Exception('not implemented yet');
+    }
+
+    private function outputAndExit(Response $response): void
+    {
+        // v Nette to převeď na IResponse, tady pro POC pošlu hlavičky a umřu
+        foreach ($response->headers->allPreserveCase() as $k => $vals) {
+            foreach ($vals as $v) header("$k: $v", false);
+        }
+        http_response_code($response->getStatusCode());
+        echo $response->getContent();
+        exit;
+    }
+}
+

--- a/src/Adapter/OneLoginAdapter.php
+++ b/src/Adapter/OneLoginAdapter.php
@@ -12,7 +12,7 @@ use Sitmp\Saml\SamlAdapter;
 final class OneLoginAdapter implements SamlAdapter
 {
     private array $settings;
-    private ?Auth $auth;
+    private ?Auth $auth = null;
 
     public function __construct(array $settings)
     {
@@ -71,6 +71,7 @@ final class OneLoginAdapter implements SamlAdapter
         return new SamlAcs(
             $this->getAuth()->getNameId(),
             $this->getAuth()->getNameIdFormat(),
+            // getAttributes se plni do samlUserdata
             $this->getAuth()->getAttributes(),
             $this->getAuth()->getNameIdNameQualifier(),
             $this->getAuth()->getNameIdSPNameQualifier(),

--- a/src/Adapter/OneLoginAdapter.php
+++ b/src/Adapter/OneLoginAdapter.php
@@ -121,11 +121,17 @@ final class OneLoginAdapter implements SamlAdapter
             $requestID = null;
         }
 
-        $this->getAuth()->processSLO(false, $requestID);
+        $this->getAuth()->processSLO(
+            false,
+            $requestID,
+            false,
+            $successCallback
+        );
         $errors = $this->getAuth()->getErrors();
-        if ((empty($errors)) and ($successCallback)) {
-            $successCallback();
-        } else {
+        //if ((empty($errors)) and ($successCallback)) {
+            //$successCallback();
+        //} else {
+        if (!empty($errors)) {
             //echo '<p>', implode(', ', $errors), '</p>';
             //if ($auth->getSettings()->isDebugActive()) {
             //    echo '<p>' . $auth->getLastErrorReason() . '</p>';

--- a/src/Adapter/OneLoginAdapter.php
+++ b/src/Adapter/OneLoginAdapter.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Sitmp\Saml\Adapter;
+
+use OneLogin\Saml2\Auth;
+use OneLogin\Saml2\Settings;
+use OneLogin\Saml2\Utils;
+use OneLogin\Saml2\ValidationError;
+use Sitmp\Saml\SamlAcs;
+use Sitmp\Saml\SamlAdapter;
+
+final class OneLoginAdapter implements SamlAdapter
+{
+    private array $settings;
+    private ?Auth $auth;
+
+    public function __construct(array $settings)
+    {
+        $this->settings = $settings;
+        Utils::setProxyVars(true);
+    }
+
+    private function getAuth(): Auth
+    {
+        if (!$this->auth) $this->auth = new Auth($this->settings);
+        return $this->auth;
+    }
+
+    public function login(?string $returnTo = null): void
+    {
+        $this->getAuth()->login($returnTo);
+    }
+
+    public function acs($authErrorCallback,$genericErrorCallback): SamlAcs
+    {
+        if (isset($_SESSION) && isset($_SESSION['AuthNRequestID'])) {
+            $requestID = $_SESSION['AuthNRequestID'];
+        } else {
+            $requestID = null;
+        }
+        try {
+            $this->getAuth()->processResponse($requestID);
+        } catch (ValidationError $e) {
+            //$this->handleAuthError($e);
+            $authErrorCallback($e);
+        } catch (\Exception $e) {
+            // for example unsupported method
+            //$this->handleGenericError($e);
+            $genericErrorCallback($e);
+        }
+
+        $errors = $this->getAuth()->getErrors();
+        if (!empty($errors)) {
+            /*echo '<p>', implode(', ', $errors), '</p>';
+            if ($auth->getSettings()->isDebugActive()) {
+                echo '<p>' . $auth->getLastErrorReason() . '</p>';
+            }*/
+            $errorMessage = implode(', ', $errors);
+            if ($this->getAuth()->getSettings()->isDebugActive()) {
+                $errorMessage = $this->getAuth()->getLastErrorReason();
+            }
+            $authErrorCallback(new \Exception($errorMessage));
+        }
+
+        if (!$this->getAuth()->isAuthenticated()) {
+            //echo "<p>Not authenticated</p>";
+            //exit();
+            //$this->handleAuthError(new \Exception("Not authenticated"));
+            $authErrorCallback(new \Exception("Not authenticated"));
+        }
+        return new SamlAcs(
+            $this->getAuth()->getNameId(),
+            $this->getAuth()->getNameIdFormat(),
+            $this->getAuth()->getAttributes(),
+            $this->getAuth()->getNameIdNameQualifier(),
+            $this->getAuth()->getNameIdSPNameQualifier(),
+            $this->getAuth()->getSessionIndex()
+        );
+        //$saml = $this->getSession()->getSection('saml');
+        //$saml->samlUserdata = $auth->getAttributes();
+        //$saml->samlNameId = $auth->getNameId();
+        //$saml->samlNameIdFormat = $auth->getNameIdFormat();
+        //$saml->samlNameIdNameQualifier = $auth->getNameIdNameQualifier();
+        //$saml->samlNameIdSPNameQualifier = $auth->getNameIdSPNameQualifier();
+        //$saml->samlSessionIndex = $auth->getSessionIndex();
+        //$saml->backlinkUrl = $this->getHttpRequest()->getPost('RelayState');
+    }
+
+    public function logout(?string $returnTo, array $parameters, mixed $nameId, mixed $sessionIndex, bool $stay, mixed $nameIdFormat, mixed $samlNameIdNameQualifier, mixed $samlNameIdSPNameQualifier): void
+    {
+        $this->getAuth()->logout($returnTo, $parameters, $nameId, $sessionIndex, $stay, $nameIdFormat, $samlNameIdNameQualifier, $samlNameIdSPNameQualifier);
+    }
+
+    public function slo($successCallback,$authErrorCallback): void
+    {
+        //$auth = new Auth($this->samlProvider->getSettingsInfo());
+        if (isset($_SESSION) && isset($_SESSION['LogoutRequestID'])) {
+            $requestID = $_SESSION['LogoutRequestID'];
+        } else {
+            $requestID = null;
+        }
+
+        $this->getAuth()->processSLO(false, $requestID);
+        $errors = $this->getAuth()->getErrors();
+        if (empty($errors)) {
+            $successCallback();
+        } else {
+            //echo '<p>', implode(', ', $errors), '</p>';
+            //if ($auth->getSettings()->isDebugActive()) {
+            //    echo '<p>' . $auth->getLastErrorReason() . '</p>';
+            //}
+            $errorMessage = implode(', ', $errors);
+            if ($this->getAuth()->getSettings()->isDebugActive()) $errorMessage .= " - ".$this->getAuth()->getLastErrorReason();
+            $authErrorCallback(new \Exception($errorMessage));
+        }
+    }
+
+    public function getMetadata(): string
+    {
+        $settingsObj = new Settings($this->settings, true);
+        $metadata = $settingsObj->getSPMetadata();
+        $errors = $settingsObj->validateMetadata($metadata);
+        if (empty($errors)) {
+            //$this->getHttpResponse()->setHeader('Content-Type', 'text/xml');
+            return $metadata;
+        } else {
+            throw new \OneLogin\Saml2\Error(
+                'Invalid SP metadata: ' . implode(', ', $errors),
+                \OneLogin\Saml2\Error::METADATA_SP_INVALID
+            );
+        }
+    }
+}

--- a/src/Adapter/OneLoginAdapter.php
+++ b/src/Adapter/OneLoginAdapter.php
@@ -142,6 +142,13 @@ final class OneLoginAdapter implements SamlAdapter
                 $authErrorCallback(new \Exception($errorMessage));
             }
         }
+        // if isset RelayState - redirect to
+        $relayState = $_GET['RelayState'] ?? null;
+        if ($relayState && Utils::getSelfURL() !== $relayState) {
+            $this->getAuth()->redirectTo($relayState);
+            exit;
+        }
+        //echo 'SLO done';
     }
 
     public function getMetadata(): string

--- a/src/Adapter/SimpleSamlAdapter.php
+++ b/src/Adapter/SimpleSamlAdapter.php
@@ -1,0 +1,128 @@
+<?php
+// nastrel SimpleSamlAdapteru
+// musi se nacist prislsna knihovna i composerem
+// composer require simplesamlphp/simplesamlphp
+declare(strict_types=1);
+
+namespace Sitmp\Saml\Adapter;
+
+use Sitmp\Saml\SamlAcs;
+use Sitmp\Saml\SamlAdapter;
+
+final class SimpleSamlAdapter implements SamlAdapter
+{
+    private array $settings;
+    private string $authSource;
+    private \SimpleSAML\Auth\Simple $as;
+
+    public function __construct(array $settings)
+    {
+        $this->settings = $settings;
+        $this->authSource = 'default-sp';
+        // private ?string $sloReturnTo = null
+        $this->as = new \SimpleSAML\Auth\Simple($this->authSource);
+
+    }
+
+
+    public function login(?string $returnTo = null): void
+    {
+        throw new \Exception('Not implemented yet');
+        /*$this->as->requireAuth([
+            'ReturnTo' => $returnTo, // může být null – SSP si vezme current URL
+        ]);*/
+    }
+
+    public function acs(?callable $authError = null, ?callable $genericError = null): SamlAcs
+    {
+        throw new \Exception('Not implemented yet');
+        /*
+        // U SimpleSAML se ACS typicky odbaví jeho endpointem.
+        // Po návratu do aplikace už jen čteme stav/session:
+        try {
+            if (!$this->as->isAuthenticated()) {
+                throw new \Exception('Not authenticated (no SAML session)');
+            }
+            $attrs = $this->as->getAttributes(); // [name => [values…]]
+            $nameId  = $this->as->getAuthData('saml:sp:NameID')['Value'] ?? null;
+            $format  = $this->as->getAuthData('saml:sp:NameID')['Format'] ?? null;
+            $nq      = $this->as->getAuthData('saml:sp:NameID')['NameQualifier'] ?? null;
+            $spnq    = $this->as->getAuthData('saml:sp:NameID')['SPNameQualifier'] ?? null;
+            $sessIdx = $this->as->getAuthData('saml:sp:SessionIndex') ?? null;
+
+            return new SamlAcs(
+                $nameId,
+                $format,
+                $attrs,
+                $nq,
+                $spnq,
+                $sessIdx
+            );
+        } catch (\Throwable $e) {
+            // SimpleSAML už řešil podpisy/bindingy – tady jen vrátíme chybu volajícímu
+            if ($authError !== null) {
+                $authError($e);
+            }
+            throw $e;
+        }*/
+    }
+
+    public function logout(
+        ?string $returnTo = null,
+        array $parameters = [],
+        ?string $nameId = null,
+        ?string $sessionIndex = null,
+        bool $stay = false,
+        ?string $nameIdFormat = null,
+        ?string $nameIdNameQualifier = null,
+        ?string $nameIdSPNameQualifier = null
+    ): void {
+        throw new \Exception('Not implemented yet');
+        /*
+        // SimpleSAML si NameID/SessionIndex vytáhne ze své session sám
+        $this->as->logout($returnTo ?? $this->sloReturnTo);
+        // pokud se sem kód vrátí, logout je lokálně hotový (SLO flow může přesměrovat)*/
+    }
+
+    public function slo(?callable $success = null, ?callable $authError = null): void
+    {
+        throw new \Exception('Not implemented yet');
+        // SLS endpoint obsluhuje SimpleSAML. Tady typicky není co dělat,
+        // ale kvůli kontraktu můžeme jen "dopsat" úspěch (jsme po návratu).
+        /*try {
+            $success();
+        } catch (\Throwable $e) {
+            if ($authError !== null) {
+                $authError($e);
+            }
+            //throw $e;
+        }*/
+    }
+
+    public function getMetadata(): string
+    {
+        throw new \Exception('Not implemented yet');
+        /*
+        // vyrobíme SP metadata programově (alternativa k SSP /metadata endpointu)
+        $entityId = \SimpleSAML\Configuration::getInstance()
+            ->getString('entityid', null); // můžeš číst i z authsources.php
+
+        $cfg = \SimpleSAML\Configuration::getInstance();
+        $metab = new \SimpleSAML\Metadata\SAMLBuilder($entityId);
+
+        $sp = [
+            'AssertionConsumerService' => [
+                ['Binding' => \SAML2\Constants::BINDING_HTTP_POST, 'Location' => $cfg->getString('assertionconsumerservice', null)],
+            ],
+            'SingleLogoutService' => [
+                ['Binding' => \SAML2\Constants::BINDING_HTTP_POST,    'Location' => $cfg->getString('singlelogoutservice', null)],
+                ['Binding' => \SAML2\Constants::BINDING_HTTP_REDIRECT, 'Location' => $cfg->getString('singlelogoutservice', null)],
+            ],
+            // volitelně: NameIDFormat, KeyDescriptor, …
+        ];
+
+        $metab->addSPSSODescriptor($sp);
+        return $metab->getEntityDescriptor()->ownerDocument->saveXML();
+        */
+    }
+}

--- a/src/DI/SamlExtension.php
+++ b/src/DI/SamlExtension.php
@@ -16,7 +16,7 @@ class SamlExtension extends CompilerExtension
         return Expect::structure([
             // doplnena moznost vyberu knihovny, ktera bude funkcionalitu zajistovat
             // onelogin neumoznuje back channel SLO s POST
-            'library' => Expect::anyOf('onelogin', 'litesaml')->default('onelogin'),
+            'library' => Expect::anyOf('onelogin', 'litesaml','simplesaml')->default('onelogin'),
             'public_IdP_key' => Expect::string()->required()->dynamic(),
             'public_SP_key' => Expect::string()->required()->dynamic(),
             'private_SP_key' => Expect::string()->required()->dynamic(),

--- a/src/DI/SamlExtension.php
+++ b/src/DI/SamlExtension.php
@@ -14,6 +14,9 @@ class SamlExtension extends CompilerExtension
     public function getConfigSchema(): Nette\Schema\Schema
     {
         return Expect::structure([
+            // doplnena moznost vyberu knihovny, ktera bude funkcionalitu zajistovat
+            // onelogin neumoznuje back channel SLO s POST
+            'library' => Expect::anyOf('onelogin', 'litesaml')->default('onelogin'),
             'public_IdP_key' => Expect::string()->required()->dynamic(),
             'public_SP_key' => Expect::string()->required()->dynamic(),
             'private_SP_key' => Expect::string()->required()->dynamic(),

--- a/src/Presenters/BaseSamlPresenter.php
+++ b/src/Presenters/BaseSamlPresenter.php
@@ -103,14 +103,15 @@ abstract class BaseSamlPresenter  extends Nette\Application\UI\Presenter
         }
     }
 
-    // what to do after successful logout?? Overwrite it to implement own "after logout" functionality
-    public function successfulLogoutAction(): void
+    // what to do after successfull slo logout?? Overwrite it to implement own "after logout" functionality
+    // nonsese - after succesfull slo app send redirect response to IdP
+    /*public function successfulLogoutAction(): void
     {
         // echo "Successfully logged out";
         // exit();
         echo "Odhlášení proběhlo v pořádku";
         $this->terminate();
-    }
+    }*/
 
 
     public function actionLogout(): void
@@ -153,7 +154,8 @@ abstract class BaseSamlPresenter  extends Nette\Application\UI\Presenter
         $this->samlProvider->slo(function () {
                 // should I call $this->getUser->logout(); ??????
                 $this->logoutNetteAppUser();
-                $this->successfulLogoutAction();
+                // only logout, let adapter to send correct LogoutResponse Success
+                //$this->successfulLogoutAction();
             },[$this,'handleAuthError']);
     }
 

--- a/src/Presenters/BaseSamlPresenter.php
+++ b/src/Presenters/BaseSamlPresenter.php
@@ -5,11 +5,6 @@ declare(strict_types=1);
 namespace Sitmp\Saml\Presenters;
 
 use Nette;
-use OneLogin;
-use OneLogin\Saml2\Auth;
-use OneLogin\Saml2\Settings;
-use OneLogin\Saml2\Utils;
-use OneLogin\Saml2\ValidationError;
 use Sitmp;
 
 abstract class BaseSamlPresenter  extends Nette\Application\UI\Presenter
@@ -23,17 +18,16 @@ abstract class BaseSamlPresenter  extends Nette\Application\UI\Presenter
     public function __construct()
     {
         parent::__construct();
-        Utils::setProxyVars(true);
     }
 
     // pokud je jako parametr zadan backlink, poslu ho i do saml jako RelayState
     public function actionDefault(?string $backlink = null): void
     {
-        $auth = new Auth($this->samlProvider->getSettingsInfo());
         $backlinkUrl = null;
         if ($backlink) $backlinkUrl = $this->backlink2Url($backlink);
-        $auth->login($backlinkUrl);
-
+        //$auth = new Auth($this->samlProvider->getSettingsInfo());
+        //$auth->login($backlinkUrl);
+        $this->samlProvider->login($backlinkUrl);
     }
 
     // convert backlink to url
@@ -45,13 +39,7 @@ abstract class BaseSamlPresenter  extends Nette\Application\UI\Presenter
         }
         $request = clone $session[$key][1];
         unset($session[$key]);
-        // marked as internal - suggested is $linkGenerator->requestToUrl
-        // required nette/application 3.2 and higher
-        if (method_exists($this->linkGenerator, 'requestToUrl')) {
-            return $this->linkGenerator->requestToUrl($request);
-        } else {
-            return $this->requestToUrl($request);
-        }
+        return $this->linkGenerator->requestToUrl($request);
     }
 
 
@@ -90,52 +78,14 @@ abstract class BaseSamlPresenter  extends Nette\Application\UI\Presenter
 
     public function actionAcs(): void
     {
-        $auth = new Auth($this->samlProvider->getSettingsInfo());
-        if (isset($_SESSION) && isset($_SESSION['AuthNRequestID'])) {
-            $requestID = $_SESSION['AuthNRequestID'];
-        } else {
-            $requestID = null;
-        }
-        try {
-            $auth->processResponse($requestID);
-        } catch (ValidationError $e) {
-            $this->handleAuthError($e);
-        } catch (\Exception $e) {
-            // for example GET method
-            $this->handleGenericError($e);
-        }
-
-        $errors = $auth->getErrors();
-        if (!empty($errors)) {
-            /*echo '<p>', implode(', ', $errors), '</p>';
-            if ($auth->getSettings()->isDebugActive()) {
-                echo '<p>' . $auth->getLastErrorReason() . '</p>';
-            }*/
-            $errorMessage = implode(', ', $errors);
-            if ($auth->getSettings()->isDebugActive()) $errorMessage = $auth->getLastErrorReason();
-            $this->handleAuthError(new \Exception($errorMessage));
-        }
-
-        if (!$auth->isAuthenticated()) {
-            //echo "<p>Not authenticated</p>";
-            //exit();
-            $this->handleAuthError(new \Exception("Not authenticated"));
-        }
+        $acsData = $this->samlProvider->acs([$this,'handleAuthError'],[$this,'handleGenericError']);
         $saml = $this->getSession()->getSection('saml');
-        $saml->samlUserdata = $auth->getAttributes();
-        $saml->samlNameId = $auth->getNameId();
-        $saml->samlNameIdFormat = $auth->getNameIdFormat();
-        $saml->samlNameIdNameQualifier = $auth->getNameIdNameQualifier();
-        $saml->samlNameIdSPNameQualifier = $auth->getNameIdSPNameQualifier();
-        $saml->samlSessionIndex = $auth->getSessionIndex();
-        //  if (isset($_POST['RelayState']) && Utils::getSelfURL() != $_POST['RelayState']) {
-        //    $this->redirect($this->samlProvider->getBacklink());
-        // }
-        // relayState is saved in session backlinkUrl (check self URL !!!)
-        $saml->backlinkUrl = $this->getHttpRequest()->getPost('RelayState');
+        foreach ($acsData as $acsKey => $acsValue) {
+            $saml->set($acsKey, $acsValue);
+        }
+        $saml->set('backlinkUrl', $this->getHttpRequest()->getPost('RelayState'));
         // and redirect to auth / autorize backlink
         $this->redirect($this->samlProvider->getBacklink());
-
     }
 
 
@@ -167,8 +117,6 @@ abstract class BaseSamlPresenter  extends Nette\Application\UI\Presenter
     {
         // should I call $this->getUser->logout(); ??????
         $this->logoutNetteAppUser();
-
-        $auth = new Auth($this->samlProvider->getSettingsInfo());
         $returnTo = null;
         $parameters = array();
         $nameId = null;
@@ -177,6 +125,8 @@ abstract class BaseSamlPresenter  extends Nette\Application\UI\Presenter
         $samlNameIdNameQualifier = null;
         $samlNameIdSPNameQualifier = null;
 
+        // TO-DO: co to je za logiku - tady vubec neni osetreno, co se deje, kdyz v session neni
+        // najednou se nepouziva  $this->getSession(), ale rovnou $_SESSION ????
         if (isset($_SESSION['samlNameId'])) {
             $nameId = $_SESSION['samlNameId'];
         }
@@ -193,54 +143,26 @@ abstract class BaseSamlPresenter  extends Nette\Application\UI\Presenter
             $sessionIndex = $_SESSION['samlSessionIndex'];
         }
 
-        $auth->logout($returnTo, $parameters, $nameId, $sessionIndex, false, $nameIdFormat, $samlNameIdNameQualifier, $samlNameIdSPNameQualifier);
+        //$auth = new Auth($this->samlProvider->getSettingsInfo());
+        //$auth->logout($returnTo, $parameters, $nameId, $sessionIndex, false, $nameIdFormat, $samlNameIdNameQualifier, $samlNameIdSPNameQualifier);
+        $this->samlProvider->logout($returnTo, $parameters, $nameId, $sessionIndex, false, $nameIdFormat, $samlNameIdNameQualifier, $samlNameIdSPNameQualifier);
     }
 
     public function actionSls(): void
     {
-        $auth = new Auth($this->samlProvider->getSettingsInfo());
-        if (isset($_SESSION) && isset($_SESSION['LogoutRequestID'])) {
-            $requestID = $_SESSION['LogoutRequestID'];
-        } else {
-            $requestID = null;
-        }
-
-        $auth->processSLO(false, $requestID);
-        $errors = $auth->getErrors();
-        if (empty($errors)) {
-            // should I call $this->getUser->logout(); ??????
-            $this->logoutNetteAppUser();
-            $this->successfulLogoutAction();
-        } else {
-            //echo '<p>', implode(', ', $errors), '</p>';
-            //if ($auth->getSettings()->isDebugActive()) {
-            //    echo '<p>' . $auth->getLastErrorReason() . '</p>';
-            //}
-            $errorMessage = implode(', ', $errors);
-            if ($auth->getSettings()->isDebugActive()) $errorMessage .= " - ".$auth->getLastErrorReason();
-            $this->handleAuthError(new \Exception($errorMessage));
-        }
+        $this->samlProvider->slo(function () {
+                // should I call $this->getUser->logout(); ??????
+                $this->logoutNetteAppUser();
+                $this->successfulLogoutAction();
+            },[$this,'handleAuthError']);
     }
 
     public function actionMetadata(): void
     {
         try {
-            #$auth = new OneLogin_Saml2_Auth($settingsInfo);
-            #$settings = $auth->getSettings();
-            // Now we only validate SP settings
-            $settings = new Settings($this->samlProvider->getSettingsInfo(), true);
-            $metadata = $settings->getSPMetadata();
-            $errors = $settings->validateMetadata($metadata);
-            if (empty($errors)) {
-                //$this->getHttpResponse()->setHeader('Content-Type', 'text/xml');
-                $this->getHttpResponse()->setContentType('text/xml', 'UTF-8');
-                $this->sendResponse(new Nette\Application\Responses\TextResponse($metadata));
-            } else {
-                throw new OneLogin\Saml2\Error(
-                    'Invalid SP metadata: ' . implode(', ', $errors),
-                    OneLogin\Saml2\Error::METADATA_SP_INVALID
-                );
-            }
+            $metadata = $this->samlProvider->getMetadata();
+            $this->getHttpResponse()->setContentType('text/xml', 'UTF-8');
+            $this->sendResponse(new Nette\Application\Responses\TextResponse($metadata));
         } catch (\Exception $e) {
             echo $e->getMessage();
             $this->terminate();

--- a/src/Presenters/BaseSamlPresenter.php
+++ b/src/Presenters/BaseSamlPresenter.php
@@ -157,6 +157,8 @@ abstract class BaseSamlPresenter  extends Nette\Application\UI\Presenter
                 // only logout, let adapter to send correct LogoutResponse Success
                 //$this->successfulLogoutAction();
             },[$this,'handleAuthError']);
+        // to be sure
+        $this->terminate();
     }
 
     public function actionMetadata(): void

--- a/src/SamlAcs.php
+++ b/src/SamlAcs.php
@@ -5,13 +5,14 @@ namespace Sitmp\Saml;
 class SamlAcs
 {
     function __construct(
-            public string $samlNameId,
-            public string $samlNameIdFormat,
-            public array $samlAttributes,
-            public string $samlNameIdNameQualifier,
-            public string $samlNameIdSPNameQualifier,
-            public ?string $samlSessionIndex = null,
-            public ?string $samlUserdata = null)
+            public ?string $samlNameId,
+            public ?string $samlNameIdFormat,
+            // tohle je zasadni - tady se hleda info o prihlasenem uzivateli
+            public array $samlUserdata,
+            public ?string $samlNameIdNameQualifier,
+            public ?string $samlNameIdSPNameQualifier,
+            public ?string $samlSessionIndex = null
+        )
     {
     }
 }

--- a/src/SamlAcs.php
+++ b/src/SamlAcs.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Sitmp\Saml;
+
+class SamlAcs
+{
+    function __construct(
+            public string $samlNameId,
+            public string $samlNameIdFormat,
+            public array $samlAttributes,
+            public string $samlNameIdNameQualifier,
+            public string $samlNameIdSPNameQualifier,
+            public ?string $samlSessionIndex = null,
+            public ?string $samlUserdata = null)
+    {
+    }
+}

--- a/src/SamlAdapter.php
+++ b/src/SamlAdapter.php
@@ -1,0 +1,16 @@
+<?php
+namespace Sitmp\Saml;
+
+interface SamlAdapter
+{
+    public function login(?string $returnTo = null): void;
+
+    function acs($authErrorCallback,$genericErrorCallback): SamlAcs;
+    public function logout(?string $returnTo, array $parameters, mixed $nameId, mixed $sessionIndex, bool $stay, mixed $nameIdFormat, mixed $samlNameIdNameQualifier, mixed $samlNameIdSPNameQualifier): void;
+
+    public function slo($successCallback,$authErrorCallback): void;
+
+    public function getMetadata(): string;
+
+
+}

--- a/src/SamlAdapter.php
+++ b/src/SamlAdapter.php
@@ -3,13 +3,40 @@ namespace Sitmp\Saml;
 
 interface SamlAdapter
 {
+    /**
+     * presmeruje na prihlasovaci stranku IDP
+     */
     public function login(?string $returnTo = null): void;
 
-    function acs($authErrorCallback,$genericErrorCallback): SamlAcs;
-    public function logout(?string $returnTo, array $parameters, mixed $nameId, mixed $sessionIndex, bool $stay, mixed $nameIdFormat, mixed $samlNameIdNameQualifier, mixed $samlNameIdSPNameQualifier): void;
+    /**
+     * Zpracuje ACS (SAMLResponse) a vrátí data o uživateli.
+     * @param callable $authErrorCallback   fn(Throwable $e): void
+     * @param callable $genericErrorCallback fn(Throwable $e): void
+     */
+    function acs(?callable $authErrorCallback = null,?callable $genericErrorCallback = null): SamlAcs;
 
-    public function slo($successCallback,$authErrorCallback): void;
+    /**
+     * Odeslání LogoutRequest na IdP
+     */
+    public function logout(
+        ?string $returnTo = null,
+        array $parameters = [],
+        ?string $nameId = null,
+        ?string $sessionIndex = null,
+        bool $stay = false,
+        ?string $nameIdFormat = null,
+        ?string $nameIdNameQualifier = null,
+        ?string $nameIdSPNameQualifier = null
+    ): void;
 
+    /**
+     * Příjem SLO požadavku na SLS endpointu (IdP → SP)
+     */
+    public function slo(?callable $successCallback = null,?callable $authErrorCallback = null): void;
+
+    /**
+     * Vygeneruje SP metadata (XML)
+     */
     public function getMetadata(): string;
 
 

--- a/src/SamlProvider.php
+++ b/src/SamlProvider.php
@@ -52,7 +52,7 @@ class SamlProvider
     private $no_publish_slo_url;
 
     private string $library;
-    private ?SamlAdapter $adapter;
+    private ?SamlAdapter $adapter = null;
 
     public function __construct(array $config, Request $url)
     {
@@ -172,6 +172,12 @@ class SamlProvider
     public function slo($successCallback,$authErrorCallback): void
     {
         $this->getAdapter()->slo($successCallback,$authErrorCallback);
+    }
+
+
+    public function getMetadata(): string
+    {
+        return $this->getAdapter()->getMetadata();
     }
 
 


### PR DESCRIPTION
An adapter architecture for the SAML integration, allowing the package to work with different underlying SAML libraries.

The default implementation still uses OneLogin PHP-SAML and change keeps full backward compatibility for existing projects using OneLogin.

This structure makes it easier to add new SAML backends (e.g., LightSAML, SimpleSAMLphp) without changing the public API of the package.